### PR TITLE
Fixed evaluation with multihead architectures

### DIFF
--- a/CL/rl/sac.py
+++ b/CL/rl/sac.py
@@ -451,7 +451,7 @@ class SAC:
         for seq_idx, test_env in enumerate(self.test_envs):
             start_time = time.time()
             key_prefix = f"test/{mode}/{seq_idx}/{test_env.name}"
-            one_hot_vec = create_one_hot_vec(test_env.num_tasks, test_env.task_id)
+            one_hot_vec = create_one_hot_vec(test_env.num_tasks, seq_idx)
 
             self.on_test_start(seq_idx)
 

--- a/COOM/env/builder.py
+++ b/COOM/env/builder.py
@@ -59,6 +59,7 @@ def make_envs(scenarios: List[Scenario],
     for i, pair in enumerate(itertools.product(zip(scenarios, scenarios_kwargs), tasks)):
         # If task_idx is specified, use that otherwise use the current index.
         task_id = task_idx if task_idx is not None else i
+        doom_kwargs['task_idx'] = task_id
         scenario_and_kwargs = pair[0]
         task = pair[1]
         scenario = scenario_and_kwargs[0]


### PR DESCRIPTION
There was a bug due to which the first output head in the model was always selected, regardless of which task in the sequence was being tested.